### PR TITLE
Add parameter for multiple hex load interval

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,8 @@ Once this is done, you can run the script by going into the `apps/desktop/` dire
 
 	python3 -m main.py
 
+To change interval for loading multiple beacons use `--interval [value in ms]` flag. More information available on `python3 main.py --help`.
+
 ## Post-mortem Beacon Parsing
 
 Upon opening the GUI, you can select a beacon to visualize by clicking on *Select Hex* and navigating to one of the decoded `.dat` files (for example, choose the file in `examples/example_beacon_raw.dat`). Once selected, the GUI will automatically start displaying beacons one second at a time. You can also scan through the beacons by clicking on the fast-foward and rewind buttons.

--- a/apps/desktop/Pantalla_Interfaz_V2.py
+++ b/apps/desktop/Pantalla_Interfaz_V2.py
@@ -119,7 +119,7 @@ class Pantalla_Interfaz(QtWidgets.QMainWindow, Ui_MainWindow):
 		step_forward() en Modo Manual
 	"""
 
-	def __init__(self, *args, parent=None):
+	def __init__(self, args, parent=None):
 		"""
 		Constructor
 
@@ -186,7 +186,7 @@ class Pantalla_Interfaz(QtWidgets.QMainWindow, Ui_MainWindow):
 		# Configuracion de timer que actualiza data
 		self.timer = QtCore.QTimer()
 		self.timer.timeout.connect(self.updatedata)
-		self.timer.start(1000)
+		self.timer.start(args.interval)
 
 		# Comenzar con todos los botones desactivados (excepto Select
 		# HEX y Conectar a puerto)

--- a/apps/desktop/main.py
+++ b/apps/desktop/main.py
@@ -9,15 +9,24 @@
 
 # Local libraries
 from PyQt5 import QtCore, QtGui, QtWidgets
+import argparse
 import sys
 
 # Own libraries
 from Pantalla_Interfaz_V2 import Pantalla_Interfaz
 
+
+# Parse arguments
+def parse_args():
+	parser = argparse.ArgumentParser()
+	parser.add_argument('--interval', '-i', help='Beacon frame loading interval (ms)', type=int, default=1000)
+	return parser.parse_args()
+
+
 # Ejecucion principal de intefaz ---------------------------------------
 if __name__ == "__main__":
 	app = QtWidgets.QApplication(sys.argv)
-	pantalla_interfaz = Pantalla_Interfaz()
+	pantalla_interfaz = Pantalla_Interfaz(parse_args())
 	pantalla_interfaz.show()
 	sys.exit(app.exec_())
 # ----------------------------------------------------------------------


### PR DESCRIPTION
While loading multiple HEX frames from one big HEX file (e.g. created from SatNOGS frames with https://github.com/alicjamusial/quetzal1-satnogs), the user has to wait 1s for each frame to load. 

In this PR I added a simple parameter with default = 1000ms (1s) to adjust the loading time of every frame for custom needs. Pretty useful if there's > 200 frames - you can it to `--interval 10` and have them loaded almost immediately :)

(and a note for the future: probably some system for navigating between loaded frames would be good - kind of timeline/slider - to avoid clicking "left" or "right" milion times).